### PR TITLE
Add stats manager getAll wrapper and StoryEngine validation test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "glondale.editor.io",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test tests/storyEngine.validateCurrentState.test.js"
+  }
+}

--- a/src/engine/StatsManager.js
+++ b/src/engine/StatsManager.js
@@ -222,6 +222,13 @@ export class StatsManager {
     return { ...this.flags };
   }
 
+  getAll() {
+    return {
+      stats: this.getAllStats(),
+      flags: this.getAllFlags()
+    };
+  }
+
   getStatDefinition(id) {
     return this.statDefinitions[id];
   }

--- a/tests/storyEngine.validateCurrentState.test.js
+++ b/tests/storyEngine.validateCurrentState.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// Minimal browser-like globals for modules that expect a DOM environment
+if (!globalThis.window) {
+  globalThis.window = {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => {}
+  };
+}
+
+if (!globalThis.localStorage) {
+  const storage = new Map();
+  globalThis.localStorage = {
+    getItem: (key) => storage.has(key) ? storage.get(key) : null,
+    setItem: (key, value) => storage.set(key, String(value)),
+    removeItem: (key) => storage.delete(key),
+    clear: () => storage.clear()
+  };
+}
+
+if (!globalThis.navigator) {
+  globalThis.navigator = { userAgent: 'node-test' };
+}
+
+if (!globalThis.location) {
+  globalThis.location = { href: 'http://localhost/test' };
+}
+
+const originalSetInterval = globalThis.setInterval;
+const originalClearInterval = globalThis.clearInterval;
+
+globalThis.setInterval = () => 0;
+globalThis.clearInterval = () => {};
+
+Object.assign(globalThis.window, {
+  location: globalThis.location,
+  localStorage: globalThis.localStorage,
+  navigator: globalThis.navigator
+});
+
+const { StoryEngine } = await import('../src/engine/StoryEngine.js');
+
+test('validateCurrentState provides combined stats and flags to validator', async (t) => {
+  t.after(() => {
+    globalThis.setInterval = originalSetInterval;
+    globalThis.clearInterval = originalClearInterval;
+  });
+
+  const engine = new StoryEngine();
+  engine.setValidationEnabled(true);
+
+  engine.adventure = {
+    id: 'adventure-test',
+    title: 'Adventure Test'
+  };
+
+  engine.currentScene = { id: 'start-scene' };
+
+  engine.statsManager.setStat('health', 42);
+  engine.statsManager.setFlag('questComplete', true);
+
+  const expectedResult = { errors: [], warnings: [], info: [] };
+  let receivedOptions;
+
+  engine.validationService = {
+    async validate(adventure, options) {
+      receivedOptions = options;
+      return expectedResult;
+    }
+  };
+
+  const result = await engine.validateCurrentState();
+
+  assert.strictEqual(result, expectedResult);
+  assert.ok(receivedOptions, 'validation should receive options');
+  assert.deepStrictEqual(receivedOptions.stats, {
+    stats: { health: 42 },
+    flags: { questComplete: true }
+  });
+  assert.strictEqual(receivedOptions.currentScene, 'start-scene');
+});


### PR DESCRIPTION
## Summary
- add a getAll convenience method to StatsManager that returns stats and flags together
- add a node-based regression test covering StoryEngine.validateCurrentState with validation enabled
- add a minimal package.json to configure the Node test runner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cacda70b088327a1b574937382f42a