### PR TITLE
Add inventory helper aggregations and tests

### DIFF
--- a/src/engine/InventoryManager.js
+++ b/src/engine/InventoryManager.js
@@ -301,8 +301,8 @@ export class InventoryManager {
    */
   getInventoryByCategory(includeHidden = false) {
     const cacheKey = `category_${includeHidden}`;
-    
-    if (this.categoryCache.has(cacheKey) && this.displayCache && 
+
+    if (this.categoryCache.has(cacheKey) && this.displayCache &&
         Date.now() - this.lastCacheUpdate < 1000) {
       return this.categoryCache.get(cacheKey);
     }
@@ -351,8 +351,56 @@ export class InventoryManager {
 
     this.categoryCache.set(cacheKey, result);
     this.lastCacheUpdate = Date.now();
-    
+
     return result;
+  }
+
+  /**
+   * Return inventory items belonging to a category
+   * @param {string} category - Category identifier
+   * @param {boolean} includeHidden - Include hidden items (default: true)
+   * @returns {Array}
+   */
+  getItemsByCategory(category, includeHidden = true) {
+    if (!category) {
+      return [];
+    }
+
+    const categorized = this.getInventoryByCategory(includeHidden);
+    const categoryData = categorized.categories.get(category);
+
+    if (!categoryData) {
+      return [];
+    }
+
+    return categoryData.items.slice();
+  }
+
+  /**
+   * Get total number of items in inventory (counts quantities)
+   * @returns {number}
+   */
+  getTotalItemCount() {
+    const state = this.getInventoryState();
+    return state.totalItems || 0;
+  }
+
+  /**
+   * Get total weight of all items
+   * @returns {number}
+   */
+  getTotalWeight() {
+    const state = this.getInventoryState();
+    return state.totalWeight || 0;
+  }
+
+  /**
+   * Get total value of all items
+   * @returns {number}
+   */
+  getTotalValue() {
+    const state = this.getInventoryState();
+    return state.totalValue || 0;
   }
 
   /**

--- a/tests/inventoryConditions.test.mjs
+++ b/tests/inventoryConditions.test.mjs
@@ -1,0 +1,82 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InventoryManager } from '../src/engine/InventoryManager.js';
+import { ConditionParser } from '../src/engine/ConditionParser.js';
+
+const createInventoryManager = () => {
+  const statsManagerStub = {
+    getStat: () => 0,
+    hasFlag: () => false,
+    getVersion: () => 0,
+    hasStatDefinition: () => false,
+    setStat: () => {}
+  };
+
+  const itemDefinitions = [
+    { id: 'sword', name: 'Sword', category: 'weapon', value: 50, weight: 5 },
+    { id: 'potion', name: 'Potion', category: 'consumable', value: 10, weight: 1, consumable: true },
+    { id: 'cloak', name: 'Cloak', category: 'armor', value: 25, weight: 3, hidden: true }
+  ];
+
+  const inventoryManager = new InventoryManager(statsManagerStub, itemDefinitions);
+
+  inventoryManager.addItem('sword', 2);
+  inventoryManager.addItem('potion', 3);
+  inventoryManager.addItem('cloak', 1);
+
+  return { inventoryManager, statsManagerStub };
+};
+
+test('InventoryManager category helpers return expected items', () => {
+  const { inventoryManager } = createInventoryManager();
+
+  const weapons = inventoryManager.getItemsByCategory('weapon');
+  assert.equal(weapons.length, 1);
+  assert.equal(weapons[0].quantity, 2);
+
+  const armorHidden = inventoryManager.getItemsByCategory('armor');
+  assert.equal(armorHidden.length, 1);
+
+  const armorVisibleOnly = inventoryManager.getItemsByCategory('armor', false);
+  assert.equal(armorVisibleOnly.length, 0);
+});
+
+test('InventoryManager aggregate helpers mirror inventory state changes', () => {
+  const { inventoryManager } = createInventoryManager();
+
+  assert.equal(inventoryManager.getTotalItemCount(), 6);
+  assert.equal(inventoryManager.getTotalWeight(), 16);
+  assert.equal(inventoryManager.getTotalValue(), 155);
+
+  inventoryManager.addItem('potion', 1);
+
+  assert.equal(inventoryManager.getTotalItemCount(), 7);
+  assert.equal(inventoryManager.getTotalWeight(), 17);
+  assert.equal(inventoryManager.getTotalValue(), 165);
+});
+
+test('ConditionParser evaluates inventory conditions without errors', () => {
+  const { inventoryManager, statsManagerStub } = createInventoryManager();
+  const parser = new ConditionParser(statsManagerStub, [], inventoryManager, []);
+
+  assert.equal(
+    parser.evaluateCondition({ type: 'inventory_category', operator: '>=', key: 'weapon', value: 1 }),
+    true
+  );
+
+  assert.equal(
+    parser.evaluateCondition({ type: 'inventory_total', operator: '>=', value: 6 }),
+    true
+  );
+
+  assert.equal(
+    parser.evaluateCondition({ type: 'inventory_weight', operator: '>', value: 15 }),
+    true
+  );
+
+  assert.equal(
+    parser.evaluateCondition({ type: 'inventory_value', operator: '==', value: 155 }),
+    true
+  );
+});


### PR DESCRIPTION
## Summary
- implement helper methods on InventoryManager that reuse cached inventory data for category lookups and totals
- add coverage for inventory helpers and ensure ConditionParser evaluates inventory-related conditions without throwing

## Testing
- node --test tests/inventoryConditions.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cacd9e3cb88327b9b32bfc39ea937f