### PR TITLE
Add inventory count setter and tests

### DIFF
--- a/src/engine/InventoryManager.js
+++ b/src/engine/InventoryManager.js
@@ -193,6 +193,109 @@ export class InventoryManager {
   }
 
   /**
+   * Set exact quantity for an inventory item
+   * @param {string} itemId - Item identifier
+   * @param {number} quantity - Desired quantity (will be clamped to valid range)
+   * @returns {Object} { success, message, newQuantity }
+   */
+  setItemCount(itemId, quantity = 0) {
+    const currentEntry = this.inventory.get(itemId);
+    const currentQuantity = currentEntry ? currentEntry.quantity : 0;
+
+    if (quantity === null || quantity === undefined) {
+      quantity = 0;
+    }
+
+    if (typeof quantity !== 'number' || Number.isNaN(quantity)) {
+      return {
+        success: false,
+        message: 'Quantity must be a valid number',
+        newQuantity: currentQuantity
+      };
+    }
+
+    if (!Number.isInteger(quantity)) {
+      quantity = Math.floor(quantity);
+    }
+
+    if (quantity < 0) {
+      return {
+        success: false,
+        message: 'Cannot set negative quantity',
+        newQuantity: currentQuantity
+      };
+    }
+
+    if (quantity === currentQuantity) {
+      return {
+        success: true,
+        message: currentEntry
+          ? `${currentEntry.item.name} already at ${currentQuantity}`
+          : `${itemId} already at 0`,
+        newQuantity: currentQuantity
+      };
+    }
+
+    if (quantity === 0) {
+      if (currentEntry) {
+        this.inventory.delete(itemId);
+        this.clearCaches();
+        this.updateStatsIntegration(itemId, -currentQuantity);
+        return {
+          success: true,
+          message: `Removed all ${currentEntry.item.name}`,
+          newQuantity: 0
+        };
+      }
+
+      return {
+        success: true,
+        message: `${itemId} already absent from inventory`,
+        newQuantity: 0
+      };
+    }
+
+    const itemDef = currentEntry?.item || this.itemDefinitions.get(itemId);
+
+    if (!itemDef) {
+      return {
+        success: false,
+        message: `Unknown item: ${itemId}`,
+        newQuantity: currentQuantity
+      };
+    }
+
+    let finalQuantity = quantity;
+    let truncated = false;
+
+    if (itemDef.maxStack && quantity > itemDef.maxStack) {
+      finalQuantity = itemDef.maxStack;
+      truncated = true;
+    }
+
+    this.inventory.set(itemId, {
+      item: itemDef,
+      quantity: finalQuantity,
+      acquiredAt: currentEntry?.acquiredAt || Date.now()
+    });
+
+    const quantityChange = finalQuantity - currentQuantity;
+
+    if (quantityChange !== 0) {
+      this.clearCaches();
+      this.updateStatsIntegration(itemId, quantityChange);
+    }
+
+    return {
+      success: true,
+      message: truncated
+        ? `Set ${itemDef.name} count to max stack of ${itemDef.maxStack}`
+        : `Set ${itemDef.name} count to ${finalQuantity}`,
+      newQuantity: finalQuantity
+    };
+  }
+
+  /**
    * Check if inventory contains item
    * @param {string} itemId - Item identifier
    * @param {number} minQuantity - Minimum required quantity (default: 1)
@@ -587,7 +690,15 @@ export class InventoryManager {
    */
   updateStatsIntegration(itemId, quantityChange) {
     // Update total item count stat if it exists
-    if (this.statsManager.hasStatDefinition('total_items')) {
+    if (!this.statsManager) {
+      return;
+    }
+
+    const hasStatDefinition = typeof this.statsManager.hasStatDefinition === 'function'
+      ? this.statsManager.hasStatDefinition('total_items')
+      : Object.prototype.hasOwnProperty.call(this.statsManager.statDefinitions || {}, 'total_items');
+
+    if (hasStatDefinition && typeof this.statsManager.getStat === 'function' && typeof this.statsManager.setStat === 'function') {
       const currentTotal = this.statsManager.getStat('total_items') || 0;
       this.statsManager.setStat('total_items', Math.max(0, currentTotal + quantityChange));
     }

--- a/src/engine/StoryEngine.js
+++ b/src/engine/StoryEngine.js
@@ -279,7 +279,7 @@ export class StoryEngine {
     
     actions.forEach(action => {
       console.log('StoryEngine: Executing action:', action.type, action.key, action.value);
-      
+
       switch (action.type) {
         case 'set_stat':
           this.statsManager.setStat(action.key, action.value);
@@ -290,18 +290,36 @@ export class StoryEngine {
         case 'set_flag':
           this.statsManager.setFlag(action.key, action.value);
           break;
-        case 'add_inventory':
-          this.inventoryManager.addItem(action.key, action.value || 1);
-          console.log(`StoryEngine: Added ${action.value || 1}x ${action.key} to inventory`);
+        case 'add_inventory': {
+          const quantity = typeof action.value === 'number' ? action.value : 1;
+          const result = this.inventoryManager.addItem(action.key, quantity);
+          if (result?.success) {
+            console.log(`StoryEngine: ${result.message}`);
+          } else if (result) {
+            console.warn(`StoryEngine: Failed to add ${action.key}: ${result.message}`);
+          }
           break;
-        case 'remove_inventory':
-          this.inventoryManager.removeItem(action.key, action.value || 1);
-          console.log(`StoryEngine: Removed ${action.value || 1}x ${action.key} from inventory`);
+        }
+        case 'remove_inventory': {
+          const quantity = typeof action.value === 'number' ? action.value : 1;
+          const result = this.inventoryManager.removeItem(action.key, quantity);
+          if (result?.success) {
+            console.log(`StoryEngine: ${result.message}`);
+          } else if (result) {
+            console.warn(`StoryEngine: Failed to remove ${action.key}: ${result.message}`);
+          }
           break;
-        case 'set_inventory':
-          this.inventoryManager.setItemCount(action.key, action.value || 0);
-          console.log(`StoryEngine: Set ${action.key} count to ${action.value || 0}`);
+        }
+        case 'set_inventory': {
+          const quantity = typeof action.value === 'number' ? action.value : 0;
+          const result = this.inventoryManager.setItemCount(action.key, quantity);
+          if (result?.success) {
+            console.log(`StoryEngine: ${result.message}`);
+          } else if (result) {
+            console.warn(`StoryEngine: Failed to set inventory for ${action.key}: ${result.message}`);
+          }
           break;
+        }
         default:
           console.warn('StoryEngine: Unknown action type:', action.type);
       }

--- a/src/engine/__tests__/setInventoryAction.test.mjs
+++ b/src/engine/__tests__/setInventoryAction.test.mjs
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict';
+
+const noop = () => {};
+
+const originalSetInterval = globalThis.setInterval;
+const originalClearInterval = globalThis.clearInterval;
+
+if (!(process?.env?.ENABLE_REAL_INTERVALS === 'true')) {
+  globalThis.setInterval = () => ({ clear: () => {} });
+  globalThis.clearInterval = () => {};
+}
+
+if (typeof globalThis.window === 'undefined') {
+  globalThis.window = {
+    addEventListener: noop,
+    removeEventListener: noop,
+    dispatchEvent: noop,
+    location: { href: 'http://localhost/test' }
+  };
+} else {
+  globalThis.window.addEventListener = globalThis.window.addEventListener || noop;
+  globalThis.window.removeEventListener = globalThis.window.removeEventListener || noop;
+  globalThis.window.dispatchEvent = globalThis.window.dispatchEvent || noop;
+  globalThis.window.location = globalThis.window.location || { href: 'http://localhost/test' };
+}
+
+if (typeof globalThis.navigator === 'undefined') {
+  globalThis.navigator = { userAgent: 'node-test' };
+}
+if (!globalThis.window.navigator) {
+  globalThis.window.navigator = globalThis.navigator;
+}
+
+if (typeof globalThis.CustomEvent === 'undefined') {
+  globalThis.CustomEvent = class CustomEvent {
+    constructor(type, params = {}) {
+      this.type = type;
+      this.detail = params.detail;
+    }
+  };
+}
+
+if (typeof globalThis.localStorage === 'undefined') {
+  const storage = new Map();
+  globalThis.localStorage = {
+    getItem: (key) => (storage.has(key) ? storage.get(key) : null),
+    setItem: (key, value) => storage.set(key, String(value)),
+    removeItem: (key) => storage.delete(key),
+    clear: () => storage.clear()
+  };
+}
+if (!globalThis.window.localStorage) {
+  globalThis.window.localStorage = globalThis.localStorage;
+}
+
+const [{ StoryEngine }, { StatsManager }] = await Promise.all([
+  import('../StoryEngine.js'),
+  import('../StatsManager.js')
+]);
+
+function createConfiguredEngine() {
+  const engine = new StoryEngine();
+  const statsManager = new StatsManager([
+    {
+      id: 'total_items',
+      name: 'Total Items',
+      type: 'number',
+      defaultValue: 0,
+      min: 0
+    }
+  ]);
+
+  engine.statsManager = statsManager;
+  engine.inventoryManager.statsManager = statsManager;
+  statsManager.setInventoryManager(engine.inventoryManager);
+
+  engine.inventoryManager.initializeInventory([
+    { id: 'potion', name: 'Potion', maxStack: 5, value: 10 },
+    { id: 'elixir', name: 'Elixir', unique: true, maxStack: 1 }
+  ]);
+
+  return engine;
+}
+
+function testSetInventoryCreatesOrUpdatesItems() {
+  const engine = createConfiguredEngine();
+  engine.executeActions([{ type: 'set_inventory', key: 'potion', value: 3 }]);
+
+  assert.equal(engine.inventoryManager.getItemCount('potion'), 3, 'potion count should be set to 3');
+  assert.equal(engine.statsManager.getStat('total_items'), 3, 'total_items stat should track new quantity');
+}
+
+function testSetInventoryRemovesItemsWhenZero() {
+  const engine = createConfiguredEngine();
+  engine.executeActions([{ type: 'set_inventory', key: 'potion', value: 2 }]);
+  engine.executeActions([{ type: 'set_inventory', key: 'potion', value: 0 }]);
+
+  assert.equal(engine.inventoryManager.getItemCount('potion'), 0, 'potion should be removed when quantity set to 0');
+  assert.equal(engine.statsManager.getStat('total_items'), 0, 'total_items should be cleared when inventory emptied');
+}
+
+function testSetInventoryRespectsMaxStack() {
+  const engine = createConfiguredEngine();
+  engine.executeActions([{ type: 'set_inventory', key: 'potion', value: 10 }]);
+
+  assert.equal(engine.inventoryManager.getItemCount('potion'), 5, 'potion should clamp to max stack of 5');
+  assert.equal(engine.statsManager.getStat('total_items'), 5, 'total_items should reflect clamped value');
+}
+
+function testSetInventoryReportsFailures() {
+  const engine = createConfiguredEngine();
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.join(' '));
+
+  try {
+    engine.executeActions([{ type: 'set_inventory', key: 'unknown_item', value: 1 }]);
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  assert.equal(engine.inventoryManager.getItemCount('unknown_item'), 0, 'unknown item should not be added');
+  assert.ok(
+    warnings.some((message) => message.includes('Failed to set inventory for unknown_item')),
+    'failure should be logged to console'
+  );
+}
+
+function testSetItemCountValidatesInput() {
+  const engine = createConfiguredEngine();
+  const result = engine.inventoryManager.setItemCount('potion', -5);
+
+  assert.equal(result.success, false, 'negative quantity should fail');
+  assert.equal(engine.inventoryManager.getItemCount('potion'), 0, 'inventory should remain unchanged on failure');
+}
+
+function runTests() {
+  testSetInventoryCreatesOrUpdatesItems();
+  testSetInventoryRemovesItemsWhenZero();
+  testSetInventoryRespectsMaxStack();
+  testSetInventoryReportsFailures();
+  testSetItemCountValidatesInput();
+}
+
+try {
+  runTests();
+  console.log('✅ set_inventory action tests passed');
+} catch (error) {
+  console.error('❌ set_inventory action tests failed');
+  console.error(error);
+  process.exitCode = 1;
+} finally {
+  if (originalSetInterval) {
+    globalThis.setInterval = originalSetInterval;
+  }
+  if (originalClearInterval) {
+    globalThis.clearInterval = originalClearInterval;
+  }
+}


### PR DESCRIPTION
## Summary
- add InventoryManager#setItemCount to adjust counts and keep stats integration aligned
- surface inventory action results in StoryEngine logging for add/remove/set workflows
- cover the set_inventory action end-to-end with a Node test harness

## Testing
- node src/engine/__tests__/setInventoryAction.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cacd9fb5388327a7e0419ba1872a9d