### PR TITLE
Ensure StoryEngine inventory stats integration stays in sync

### DIFF
--- a/src/engine/InventoryManager.js
+++ b/src/engine/InventoryManager.js
@@ -587,6 +587,10 @@ export class InventoryManager {
    */
   updateStatsIntegration(itemId, quantityChange) {
     // Update total item count stat if it exists
+    if (!this.statsManager || typeof this.statsManager.hasStatDefinition !== 'function') {
+      return;
+    }
+
     if (this.statsManager.hasStatDefinition('total_items')) {
       const currentTotal = this.statsManager.getStat('total_items') || 0;
       this.statsManager.setStat('total_items', Math.max(0, currentTotal + quantityChange));

--- a/src/engine/StatsManager.js
+++ b/src/engine/StatsManager.js
@@ -62,6 +62,10 @@ export class StatsManager {
     this.inventoryManager = inventoryManager;
   }
 
+  hasStatDefinition(statId) {
+    return Object.prototype.hasOwnProperty.call(this.statDefinitions, statId);
+  }
+
   // Enhanced stat operations
   getStat(id) {
     return this.stats[id];

--- a/src/engine/StoryEngine.js
+++ b/src/engine/StoryEngine.js
@@ -11,8 +11,9 @@ export class StoryEngine {
     this.adventure = null;
     this.currentScene = null;
     this.statsManager = new StatsManager();
-    this.inventoryManager = new InventoryManager();
-    this.conditionParser = new ConditionParser(this.statsManager, []);
+    this.inventoryManager = new InventoryManager(this.statsManager);
+    this.statsManager.setInventoryManager(this.inventoryManager);
+    this.conditionParser = new ConditionParser(this.statsManager, [], this.inventoryManager);
     this.choiceEvaluator = new ChoiceEvaluator(this.conditionParser, this.statsManager, this.inventoryManager);
     this.crossGameSaveSystem = new CrossGameSaveSystem();
     this.visitedScenes = [];
@@ -65,13 +66,15 @@ export class StoryEngine {
     
     this.adventure = adventure;
     this.statsManager = new StatsManager(adventure.stats || []);
-    
+    this.inventoryManager = new InventoryManager(this.statsManager);
+    this.statsManager.setInventoryManager(this.inventoryManager);
+
     // Initialize inventory with adventure items
     if (adventure.inventory && adventure.inventory.length > 0) {
       this.inventoryManager.initializeInventory(adventure.inventory);
       console.log('StoryEngine: Initialized inventory with', adventure.inventory.length, 'item types');
     }
-    
+
     this.conditionParser = new ConditionParser(this.statsManager, this.visitedScenes, this.inventoryManager);
     this.choiceEvaluator = new ChoiceEvaluator(this.conditionParser, this.statsManager, this.inventoryManager);
     

--- a/src/engine/__tests__/inventoryStatsIntegration.test.js
+++ b/src/engine/__tests__/inventoryStatsIntegration.test.js
@@ -1,0 +1,145 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+
+let StoryEngine;
+
+beforeAll(async () => {
+  if (!globalThis.window) {
+    globalThis.window = {
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => {}
+    };
+  }
+
+  if (!globalThis.localStorage) {
+    const storage = new Map();
+    globalThis.localStorage = {
+      getItem: (key) => (storage.has(key) ? storage.get(key) : null),
+      setItem: (key, value) => storage.set(key, String(value)),
+      removeItem: (key) => storage.delete(key),
+      clear: () => storage.clear()
+    };
+  }
+
+  if (!globalThis.CustomEvent) {
+    globalThis.CustomEvent = class CustomEvent {
+      constructor(type, init = {}) {
+        this.type = type;
+        this.detail = init.detail;
+      }
+    };
+  }
+
+  ({ StoryEngine } = await import('../StoryEngine.js'));
+});
+
+const createAdventureWithTotalItemsStat = () => ({
+  title: 'Inventory Stat Adventure',
+  startSceneId: 'start',
+  scenes: [
+    {
+      id: 'start',
+      title: 'Start',
+      content: 'Start',
+      choices: [
+        {
+          id: 'gain_item',
+          text: 'Gain item',
+          targetSceneId: 'afterGain',
+          actions: [
+            { type: 'add_inventory', key: 'potion', value: 2 }
+          ]
+        }
+      ]
+    },
+    {
+      id: 'afterGain',
+      title: 'After Gain',
+      content: 'After gain',
+      choices: [
+        {
+          id: 'remove_item',
+          text: 'Remove item',
+          targetSceneId: 'end',
+          actions: [
+            { type: 'remove_inventory', key: 'potion', value: 1 }
+          ]
+        }
+      ]
+    },
+    {
+      id: 'end',
+      title: 'End',
+      content: 'End',
+      choices: []
+    }
+  ],
+  stats: [
+    { id: 'total_items', name: 'Total Items', type: 'number', defaultValue: 0, min: 0 }
+  ],
+  inventory: [
+    { id: 'potion', name: 'Potion', maxStack: 10 }
+  ]
+});
+
+const createAdventureWithoutTotalItemsStat = () => ({
+  title: 'Inventory Adventure',
+  startSceneId: 'start',
+  scenes: [
+    {
+      id: 'start',
+      title: 'Start',
+      content: 'Start',
+      choices: [
+        {
+          id: 'gain_item',
+          text: 'Gain item',
+          targetSceneId: 'end',
+          actions: [
+            { type: 'add_inventory', key: 'potion', value: 1 }
+          ]
+        }
+      ]
+    },
+    {
+      id: 'end',
+      title: 'End',
+      content: 'End',
+      choices: []
+    }
+  ],
+  stats: [],
+  inventory: [
+    { id: 'potion', name: 'Potion', maxStack: 10 }
+  ]
+});
+
+describe('StoryEngine inventory and stats integration', () => {
+  it('keeps total_items stat in sync when adding and removing items during gameplay', async () => {
+    const engine = new StoryEngine();
+    engine.validationEnabled = false;
+
+    await engine.loadAdventure(createAdventureWithTotalItemsStat());
+
+    expect(() => engine.makeChoice('gain_item')).not.toThrow();
+
+    expect(engine.inventoryManager.getItemCount('potion')).toBe(2);
+    expect(engine.statsManager.getStat('total_items')).toBe(2);
+
+    expect(() => engine.makeChoice('remove_item')).not.toThrow();
+
+    expect(engine.inventoryManager.getItemCount('potion')).toBe(1);
+    expect(engine.statsManager.getStat('total_items')).toBe(1);
+  });
+
+  it('does not throw when inventory changes and no total_items stat is defined', async () => {
+    const engine = new StoryEngine();
+    engine.validationEnabled = false;
+
+    await engine.loadAdventure(createAdventureWithoutTotalItemsStat());
+
+    expect(() => engine.makeChoice('gain_item')).not.toThrow();
+    expect(engine.inventoryManager.getItemCount('potion')).toBe(1);
+    expect(engine.statsManager.getStat('total_items')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- wire StoryEngine's InventoryManager to the active StatsManager when constructing and when loading adventures
- add StatsManager.hasStatDefinition and guard InventoryManager stat updates when no manager is attached
- add bun tests covering inventory-driven stat updates and regression for missing total-items stat

## Testing
- bun test src/engine/__tests__/inventoryStatsIntegration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cacda54fa883279a2945b5d83e1864