### PR TITLE
Implement inventory count setter with tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "glondale.editor.io",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test tests/storyEngine.validateCurrentState.test.js"
+  }
+}

--- a/src/engine/StatsManager.js
+++ b/src/engine/StatsManager.js
@@ -62,6 +62,10 @@ export class StatsManager {
     this.inventoryManager = inventoryManager;
   }
 
+  hasStatDefinition(statId) {
+    return Object.prototype.hasOwnProperty.call(this.statDefinitions, statId);
+  }
+
   // Enhanced stat operations
   getStat(id) {
     return this.stats[id];
@@ -220,6 +224,13 @@ export class StatsManager {
 
   getAllFlags() {
     return { ...this.flags };
+  }
+
+  getAll() {
+    return {
+      stats: this.getAllStats(),
+      flags: this.getAllFlags()
+    };
   }
 
   getStatDefinition(id) {

--- a/src/engine/StoryEngine.js
+++ b/src/engine/StoryEngine.js
@@ -11,8 +11,9 @@ export class StoryEngine {
     this.adventure = null;
     this.currentScene = null;
     this.statsManager = new StatsManager();
-    this.inventoryManager = new InventoryManager();
-    this.conditionParser = new ConditionParser(this.statsManager, []);
+    this.inventoryManager = new InventoryManager(this.statsManager);
+    this.statsManager.setInventoryManager(this.inventoryManager);
+    this.conditionParser = new ConditionParser(this.statsManager, [], this.inventoryManager);
     this.choiceEvaluator = new ChoiceEvaluator(this.conditionParser, this.statsManager, this.inventoryManager);
     this.crossGameSaveSystem = new CrossGameSaveSystem();
     this.visitedScenes = [];
@@ -65,13 +66,15 @@ export class StoryEngine {
     
     this.adventure = adventure;
     this.statsManager = new StatsManager(adventure.stats || []);
-    
+    this.inventoryManager = new InventoryManager(this.statsManager);
+    this.statsManager.setInventoryManager(this.inventoryManager);
+
     // Initialize inventory with adventure items
     if (adventure.inventory && adventure.inventory.length > 0) {
       this.inventoryManager.initializeInventory(adventure.inventory);
       console.log('StoryEngine: Initialized inventory with', adventure.inventory.length, 'item types');
     }
-    
+
     this.conditionParser = new ConditionParser(this.statsManager, this.visitedScenes, this.inventoryManager);
     this.choiceEvaluator = new ChoiceEvaluator(this.conditionParser, this.statsManager, this.inventoryManager);
     
@@ -274,9 +277,9 @@ export class StoryEngine {
   // Execute actions with inventory support
   executeActions(actions) {
     if (!actions || actions.length === 0) return;
-    
+
     console.log('StoryEngine: Executing', actions.length, 'actions');
-    
+
     actions.forEach(action => {
       console.log('StoryEngine: Executing action:', action.type, action.key, action.value);
       
@@ -290,22 +293,45 @@ export class StoryEngine {
         case 'set_flag':
           this.statsManager.setFlag(action.key, action.value);
           break;
-        case 'add_inventory':
-          this.inventoryManager.addItem(action.key, action.value || 1);
-          console.log(`StoryEngine: Added ${action.value || 1}x ${action.key} to inventory`);
+        case 'add_inventory': {
+          const quantity = action.value || 1;
+          const result = this.inventoryManager.addItem(action.key, quantity);
+          this.logInventoryOutcome(result, `Added ${quantity}x ${action.key} to inventory`);
           break;
-        case 'remove_inventory':
-          this.inventoryManager.removeItem(action.key, action.value || 1);
-          console.log(`StoryEngine: Removed ${action.value || 1}x ${action.key} from inventory`);
+        }
+        case 'remove_inventory': {
+          const quantity = action.value || 1;
+          const result = this.inventoryManager.removeItem(action.key, quantity);
+          this.logInventoryOutcome(result, `Removed ${quantity}x ${action.key} from inventory`);
           break;
-        case 'set_inventory':
-          this.inventoryManager.setItemCount(action.key, action.value || 0);
-          console.log(`StoryEngine: Set ${action.key} count to ${action.value || 0}`);
+        }
+        case 'set_inventory': {
+          const quantity = action.value ?? 0;
+          const result = this.inventoryManager.setItemCount(action.key, quantity);
+          if (result && result.success === false) {
+            console.warn(`StoryEngine: Failed to set inventory for ${action.key}: ${result.message}`);
+          } else {
+            this.logInventoryOutcome(result, `Set ${action.key} count to ${quantity}`);
+          }
           break;
+        }
         default:
           console.warn('StoryEngine: Unknown action type:', action.type);
       }
     });
+  }
+
+  logInventoryOutcome(result, fallbackMessage) {
+    const message = result && typeof result.message === 'string'
+      ? result.message
+      : fallbackMessage;
+
+    if (!message) {
+      return;
+    }
+
+    const logger = result && result.success === false ? console.warn : console.log;
+    logger(`StoryEngine: ${message}`);
   }
 
   // Load from save data with Phase 3 features

--- a/src/engine/__tests__/inventoryStatsIntegration.test.js
+++ b/src/engine/__tests__/inventoryStatsIntegration.test.js
@@ -1,0 +1,119 @@
+import '../../test/setupBrowserEnv.js';
+import { beforeAll, describe, expect, it } from 'bun:test';
+
+let StoryEngine;
+
+beforeAll(async () => {
+  ({ StoryEngine } = await import('../StoryEngine.js'));
+});
+
+const createAdventureWithTotalItemsStat = () => ({
+  title: 'Inventory Stat Adventure',
+  startSceneId: 'start',
+  scenes: [
+    {
+      id: 'start',
+      title: 'Start',
+      content: 'Start',
+      choices: [
+        {
+          id: 'gain_item',
+          text: 'Gain item',
+          targetSceneId: 'afterGain',
+          actions: [
+            { type: 'add_inventory', key: 'potion', value: 2 }
+          ]
+        }
+      ]
+    },
+    {
+      id: 'afterGain',
+      title: 'After Gain',
+      content: 'After gain',
+      choices: [
+        {
+          id: 'remove_item',
+          text: 'Remove item',
+          targetSceneId: 'end',
+          actions: [
+            { type: 'remove_inventory', key: 'potion', value: 1 }
+          ]
+        }
+      ]
+    },
+    {
+      id: 'end',
+      title: 'End',
+      content: 'End',
+      choices: []
+    }
+  ],
+  stats: [
+    { id: 'total_items', name: 'Total Items', type: 'number', defaultValue: 0, min: 0 }
+  ],
+  inventory: [
+    { id: 'potion', name: 'Potion', maxStack: 10 }
+  ]
+});
+
+const createAdventureWithoutTotalItemsStat = () => ({
+  title: 'Inventory Adventure',
+  startSceneId: 'start',
+  scenes: [
+    {
+      id: 'start',
+      title: 'Start',
+      content: 'Start',
+      choices: [
+        {
+          id: 'gain_item',
+          text: 'Gain item',
+          targetSceneId: 'end',
+          actions: [
+            { type: 'add_inventory', key: 'potion', value: 1 }
+          ]
+        }
+      ]
+    },
+    {
+      id: 'end',
+      title: 'End',
+      content: 'End',
+      choices: []
+    }
+  ],
+  stats: [],
+  inventory: [
+    { id: 'potion', name: 'Potion', maxStack: 10 }
+  ]
+});
+
+describe('StoryEngine inventory and stats integration', () => {
+  it('keeps total_items stat in sync when adding and removing items during gameplay', async () => {
+    const engine = new StoryEngine();
+    engine.validationEnabled = false;
+
+    await engine.loadAdventure(createAdventureWithTotalItemsStat());
+
+    expect(() => engine.makeChoice('gain_item')).not.toThrow();
+
+    expect(engine.inventoryManager.getItemCount('potion')).toBe(2);
+    expect(engine.statsManager.getStat('total_items')).toBe(2);
+
+    expect(() => engine.makeChoice('remove_item')).not.toThrow();
+
+    expect(engine.inventoryManager.getItemCount('potion')).toBe(1);
+    expect(engine.statsManager.getStat('total_items')).toBe(1);
+  });
+
+  it('does not throw when inventory changes and no total_items stat is defined', async () => {
+    const engine = new StoryEngine();
+    engine.validationEnabled = false;
+
+    await engine.loadAdventure(createAdventureWithoutTotalItemsStat());
+
+    expect(() => engine.makeChoice('gain_item')).not.toThrow();
+    expect(engine.inventoryManager.getItemCount('potion')).toBe(1);
+    expect(engine.statsManager.getStat('total_items')).toBeUndefined();
+  });
+});

--- a/src/engine/__tests__/setInventoryAction.test.js
+++ b/src/engine/__tests__/setInventoryAction.test.js
@@ -1,0 +1,218 @@
+import '../../test/setupBrowserEnv.js';
+import { beforeAll, describe, expect, it } from 'bun:test';
+
+let StoryEngine;
+
+beforeAll(async () => {
+  ({ StoryEngine } = await import('../StoryEngine.js'));
+});
+
+const baseInventory = [
+  { id: 'potion', name: 'Potion', maxStack: 5 }
+];
+
+const totalItemsStat = [
+  { id: 'total_items', name: 'Total Items', type: 'number', defaultValue: 0, min: 0 }
+];
+
+describe('StoryEngine set_inventory action', () => {
+  it('sets inventory counts directly and updates stats', async () => {
+    const engine = new StoryEngine();
+    engine.validationEnabled = false;
+
+    await engine.loadAdventure({
+      title: 'Set Inventory Adventure',
+      startSceneId: 'start',
+      scenes: [
+        {
+          id: 'start',
+          title: 'Start',
+          content: 'Start',
+          choices: [
+            {
+              id: 'set_to_three',
+              text: 'Set to three',
+              targetSceneId: 'end',
+              actions: [
+                { type: 'set_inventory', key: 'potion', value: 3 }
+              ]
+            }
+          ]
+        },
+        {
+          id: 'end',
+          title: 'End',
+          content: 'End',
+          choices: []
+        }
+      ],
+      stats: totalItemsStat,
+      inventory: baseInventory
+    });
+
+    expect(engine.inventoryManager.getItemCount('potion')).toBe(0);
+    expect(engine.statsManager.getStat('total_items')).toBe(0);
+
+    expect(() => engine.makeChoice('set_to_three')).not.toThrow();
+
+    expect(engine.inventoryManager.getItemCount('potion')).toBe(3);
+    expect(engine.statsManager.getStat('total_items')).toBe(3);
+  });
+
+  it('removes entries when quantity is set to zero', async () => {
+    const engine = new StoryEngine();
+    engine.validationEnabled = false;
+
+    await engine.loadAdventure({
+      title: 'Set Inventory Adventure',
+      startSceneId: 'start',
+      scenes: [
+        {
+          id: 'start',
+          title: 'Start',
+          content: 'Start',
+          choices: [
+            {
+              id: 'prime_inventory',
+              text: 'Prime inventory',
+              targetSceneId: 'mid',
+              actions: [
+                { type: 'set_inventory', key: 'potion', value: 4 }
+              ]
+            }
+          ]
+        },
+        {
+          id: 'mid',
+          title: 'Mid',
+          content: 'Mid',
+          choices: [
+            {
+              id: 'clear_inventory',
+              text: 'Clear inventory',
+              targetSceneId: 'end',
+              actions: [
+                { type: 'set_inventory', key: 'potion', value: 0 }
+              ]
+            }
+          ]
+        },
+        {
+          id: 'end',
+          title: 'End',
+          content: 'End',
+          choices: []
+        }
+      ],
+      stats: totalItemsStat,
+      inventory: baseInventory
+    });
+
+    expect(() => engine.makeChoice('prime_inventory')).not.toThrow();
+    expect(engine.inventoryManager.getItemCount('potion')).toBe(4);
+    expect(engine.statsManager.getStat('total_items')).toBe(4);
+
+    expect(() => engine.makeChoice('clear_inventory')).not.toThrow();
+    expect(engine.inventoryManager.getItemCount('potion')).toBe(0);
+    expect(engine.inventoryManager.hasItem('potion')).toBe(false);
+    expect(engine.statsManager.getStat('total_items')).toBe(0);
+  });
+
+  it('clamps counts to the item max stack', async () => {
+    const engine = new StoryEngine();
+    engine.validationEnabled = false;
+
+    await engine.loadAdventure({
+      title: 'Clamp Inventory Adventure',
+      startSceneId: 'start',
+      scenes: [
+        {
+          id: 'start',
+          title: 'Start',
+          content: 'Start',
+          choices: [
+            {
+              id: 'overfill_inventory',
+              text: 'Overfill inventory',
+              targetSceneId: 'end',
+              actions: [
+                { type: 'set_inventory', key: 'potion', value: 12 }
+              ]
+            }
+          ]
+        },
+        {
+          id: 'end',
+          title: 'End',
+          content: 'End',
+          choices: []
+        }
+      ],
+      stats: totalItemsStat,
+      inventory: baseInventory
+    });
+
+    expect(() => engine.makeChoice('overfill_inventory')).not.toThrow();
+    expect(engine.inventoryManager.getItemCount('potion')).toBe(5);
+    expect(engine.statsManager.getStat('total_items')).toBe(5);
+  });
+
+  it('rejects negative quantities without changing inventory', async () => {
+    const engine = new StoryEngine();
+    engine.validationEnabled = false;
+
+    await engine.loadAdventure({
+      title: 'Negative Inventory Adventure',
+      startSceneId: 'start',
+      scenes: [
+        {
+          id: 'start',
+          title: 'Start',
+          content: 'Start',
+          choices: [
+            {
+              id: 'seed_inventory',
+              text: 'Seed inventory',
+              targetSceneId: 'mid',
+              actions: [
+                { type: 'set_inventory', key: 'potion', value: 2 }
+              ]
+            }
+          ]
+        },
+        {
+          id: 'mid',
+          title: 'Mid',
+          content: 'Mid',
+          choices: [
+            {
+              id: 'negative_inventory',
+              text: 'Negative inventory',
+              targetSceneId: 'end',
+              actions: [
+                { type: 'set_inventory', key: 'potion', value: -1 }
+              ]
+            }
+          ]
+        },
+        {
+          id: 'end',
+          title: 'End',
+          content: 'End',
+          choices: []
+        }
+      ],
+      stats: totalItemsStat,
+      inventory: baseInventory
+    });
+
+    expect(() => engine.makeChoice('seed_inventory')).not.toThrow();
+    expect(engine.inventoryManager.getItemCount('potion')).toBe(2);
+    expect(engine.statsManager.getStat('total_items')).toBe(2);
+
+    expect(() => engine.makeChoice('negative_inventory')).not.toThrow();
+    expect(engine.inventoryManager.getItemCount('potion')).toBe(2);
+    expect(engine.statsManager.getStat('total_items')).toBe(2);
+  });
+});
+

--- a/src/engine/__tests__/setInventoryAction.test.mjs
+++ b/src/engine/__tests__/setInventoryAction.test.mjs
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict';
+
+const noop = () => {};
+
+const originalSetInterval = globalThis.setInterval;
+const originalClearInterval = globalThis.clearInterval;
+
+if (!(process?.env?.ENABLE_REAL_INTERVALS === 'true')) {
+  globalThis.setInterval = () => ({ clear: () => {} });
+  globalThis.clearInterval = () => {};
+}
+
+if (typeof globalThis.window === 'undefined') {
+  globalThis.window = {
+    addEventListener: noop,
+    removeEventListener: noop,
+    dispatchEvent: noop,
+    location: { href: 'http://localhost/test' }
+  };
+} else {
+  globalThis.window.addEventListener = globalThis.window.addEventListener || noop;
+  globalThis.window.removeEventListener = globalThis.window.removeEventListener || noop;
+  globalThis.window.dispatchEvent = globalThis.window.dispatchEvent || noop;
+  globalThis.window.location = globalThis.window.location || { href: 'http://localhost/test' };
+}
+
+if (typeof globalThis.navigator === 'undefined') {
+  globalThis.navigator = { userAgent: 'node-test' };
+}
+if (!globalThis.window.navigator) {
+  globalThis.window.navigator = globalThis.navigator;
+}
+
+if (typeof globalThis.CustomEvent === 'undefined') {
+  globalThis.CustomEvent = class CustomEvent {
+    constructor(type, params = {}) {
+      this.type = type;
+      this.detail = params.detail;
+    }
+  };
+}
+
+if (typeof globalThis.localStorage === 'undefined') {
+  const storage = new Map();
+  globalThis.localStorage = {
+    getItem: (key) => (storage.has(key) ? storage.get(key) : null),
+    setItem: (key, value) => storage.set(key, String(value)),
+    removeItem: (key) => storage.delete(key),
+    clear: () => storage.clear()
+  };
+}
+if (!globalThis.window.localStorage) {
+  globalThis.window.localStorage = globalThis.localStorage;
+}
+
+const [{ StoryEngine }, { StatsManager }] = await Promise.all([
+  import('../StoryEngine.js'),
+  import('../StatsManager.js')
+]);
+
+function createConfiguredEngine() {
+  const engine = new StoryEngine();
+  const statsManager = new StatsManager([
+    {
+      id: 'total_items',
+      name: 'Total Items',
+      type: 'number',
+      defaultValue: 0,
+      min: 0
+    }
+  ]);
+
+  engine.statsManager = statsManager;
+  engine.inventoryManager.statsManager = statsManager;
+  statsManager.setInventoryManager(engine.inventoryManager);
+
+  engine.inventoryManager.initializeInventory([
+    { id: 'potion', name: 'Potion', maxStack: 5, value: 10 },
+    { id: 'elixir', name: 'Elixir', unique: true, maxStack: 1 }
+  ]);
+
+  return engine;
+}
+
+function testSetInventoryCreatesOrUpdatesItems() {
+  const engine = createConfiguredEngine();
+  engine.executeActions([{ type: 'set_inventory', key: 'potion', value: 3 }]);
+
+  assert.equal(engine.inventoryManager.getItemCount('potion'), 3, 'potion count should be set to 3');
+  assert.equal(engine.statsManager.getStat('total_items'), 3, 'total_items stat should track new quantity');
+}
+
+function testSetInventoryRemovesItemsWhenZero() {
+  const engine = createConfiguredEngine();
+  engine.executeActions([{ type: 'set_inventory', key: 'potion', value: 2 }]);
+  engine.executeActions([{ type: 'set_inventory', key: 'potion', value: 0 }]);
+
+  assert.equal(engine.inventoryManager.getItemCount('potion'), 0, 'potion should be removed when quantity set to 0');
+  assert.equal(engine.statsManager.getStat('total_items'), 0, 'total_items should be cleared when inventory emptied');
+}
+
+function testSetInventoryRespectsMaxStack() {
+  const engine = createConfiguredEngine();
+  engine.executeActions([{ type: 'set_inventory', key: 'potion', value: 10 }]);
+
+  assert.equal(engine.inventoryManager.getItemCount('potion'), 5, 'potion should clamp to max stack of 5');
+  assert.equal(engine.statsManager.getStat('total_items'), 5, 'total_items should reflect clamped value');
+}
+
+function testSetInventoryReportsFailures() {
+  const engine = createConfiguredEngine();
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.join(' '));
+
+  try {
+    engine.executeActions([{ type: 'set_inventory', key: 'unknown_item', value: 1 }]);
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  assert.equal(engine.inventoryManager.getItemCount('unknown_item'), 0, 'unknown item should not be added');
+  assert.ok(
+    warnings.some((message) => message.includes('Failed to set inventory for unknown_item')),
+    'failure should be logged to console'
+  );
+}
+
+function testSetItemCountValidatesInput() {
+  const engine = createConfiguredEngine();
+  const result = engine.inventoryManager.setItemCount('potion', -5);
+
+  assert.equal(result.success, false, 'negative quantity should fail');
+  assert.equal(engine.inventoryManager.getItemCount('potion'), 0, 'inventory should remain unchanged on failure');
+}
+
+function runTests() {
+  testSetInventoryCreatesOrUpdatesItems();
+  testSetInventoryRemovesItemsWhenZero();
+  testSetInventoryRespectsMaxStack();
+  testSetInventoryReportsFailures();
+  testSetItemCountValidatesInput();
+}
+
+try {
+  runTests();
+  console.log('✅ set_inventory action tests passed');
+} catch (error) {
+  console.error('❌ set_inventory action tests failed');
+  console.error(error);
+  process.exitCode = 1;
+} finally {
+  if (originalSetInterval) {
+    globalThis.setInterval = originalSetInterval;
+  }
+  if (originalClearInterval) {
+    globalThis.clearInterval = originalClearInterval;
+  }
+}

--- a/src/test/setupBrowserEnv.js
+++ b/src/test/setupBrowserEnv.js
@@ -1,0 +1,64 @@
+const ensureWindow = () => {
+  if (typeof globalThis.window === 'undefined') {
+    globalThis.window = {
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => {}
+    };
+  } else {
+    globalThis.window.addEventListener = globalThis.window.addEventListener || (() => {});
+    globalThis.window.removeEventListener = globalThis.window.removeEventListener || (() => {});
+    globalThis.window.dispatchEvent = globalThis.window.dispatchEvent || (() => {});
+  }
+};
+
+const ensureLocalStorage = () => {
+  if (typeof globalThis.localStorage === 'undefined') {
+    const storage = new Map();
+    globalThis.localStorage = {
+      getItem: (key) => (storage.has(key) ? storage.get(key) : null),
+      setItem: (key, value) => storage.set(key, String(value)),
+      removeItem: (key) => storage.delete(key),
+      clear: () => storage.clear()
+    };
+  }
+};
+
+const ensureNavigator = () => {
+  if (typeof globalThis.navigator === 'undefined') {
+    globalThis.navigator = { userAgent: 'test-suite' };
+  }
+};
+
+const ensureLocation = () => {
+  if (typeof globalThis.location === 'undefined') {
+    globalThis.location = { href: 'http://localhost/test' };
+  }
+};
+
+const ensureCustomEvent = () => {
+  if (typeof globalThis.CustomEvent === 'undefined') {
+    globalThis.CustomEvent = class CustomEvent {
+      constructor(type, init = {}) {
+        this.type = type;
+        this.detail = init.detail;
+      }
+    };
+  }
+};
+
+const wireWindowGlobals = () => {
+  if (typeof globalThis.window !== 'undefined') {
+    globalThis.window.localStorage = globalThis.window.localStorage || globalThis.localStorage;
+    globalThis.window.navigator = globalThis.window.navigator || globalThis.navigator;
+    globalThis.window.location = globalThis.window.location || globalThis.location;
+  }
+};
+
+ensureWindow();
+ensureLocalStorage();
+ensureNavigator();
+ensureLocation();
+ensureCustomEvent();
+wireWindowGlobals();
+

--- a/tests/inventoryConditions.test.mjs
+++ b/tests/inventoryConditions.test.mjs
@@ -1,0 +1,82 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InventoryManager } from '../src/engine/InventoryManager.js';
+import { ConditionParser } from '../src/engine/ConditionParser.js';
+
+const createInventoryManager = () => {
+  const statsManagerStub = {
+    getStat: () => 0,
+    hasFlag: () => false,
+    getVersion: () => 0,
+    hasStatDefinition: () => false,
+    setStat: () => {}
+  };
+
+  const itemDefinitions = [
+    { id: 'sword', name: 'Sword', category: 'weapon', value: 50, weight: 5 },
+    { id: 'potion', name: 'Potion', category: 'consumable', value: 10, weight: 1, consumable: true },
+    { id: 'cloak', name: 'Cloak', category: 'armor', value: 25, weight: 3, hidden: true }
+  ];
+
+  const inventoryManager = new InventoryManager(statsManagerStub, itemDefinitions);
+
+  inventoryManager.addItem('sword', 2);
+  inventoryManager.addItem('potion', 3);
+  inventoryManager.addItem('cloak', 1);
+
+  return { inventoryManager, statsManagerStub };
+};
+
+test('InventoryManager category helpers return expected items', () => {
+  const { inventoryManager } = createInventoryManager();
+
+  const weapons = inventoryManager.getItemsByCategory('weapon');
+  assert.equal(weapons.length, 1);
+  assert.equal(weapons[0].quantity, 2);
+
+  const armorHidden = inventoryManager.getItemsByCategory('armor');
+  assert.equal(armorHidden.length, 1);
+
+  const armorVisibleOnly = inventoryManager.getItemsByCategory('armor', false);
+  assert.equal(armorVisibleOnly.length, 0);
+});
+
+test('InventoryManager aggregate helpers mirror inventory state changes', () => {
+  const { inventoryManager } = createInventoryManager();
+
+  assert.equal(inventoryManager.getTotalItemCount(), 6);
+  assert.equal(inventoryManager.getTotalWeight(), 16);
+  assert.equal(inventoryManager.getTotalValue(), 155);
+
+  inventoryManager.addItem('potion', 1);
+
+  assert.equal(inventoryManager.getTotalItemCount(), 7);
+  assert.equal(inventoryManager.getTotalWeight(), 17);
+  assert.equal(inventoryManager.getTotalValue(), 165);
+});
+
+test('ConditionParser evaluates inventory conditions without errors', () => {
+  const { inventoryManager, statsManagerStub } = createInventoryManager();
+  const parser = new ConditionParser(statsManagerStub, [], inventoryManager, []);
+
+  assert.equal(
+    parser.evaluateCondition({ type: 'inventory_category', operator: '>=', key: 'weapon', value: 1 }),
+    true
+  );
+
+  assert.equal(
+    parser.evaluateCondition({ type: 'inventory_total', operator: '>=', value: 6 }),
+    true
+  );
+
+  assert.equal(
+    parser.evaluateCondition({ type: 'inventory_weight', operator: '>', value: 15 }),
+    true
+  );
+
+  assert.equal(
+    parser.evaluateCondition({ type: 'inventory_value', operator: '==', value: 155 }),
+    true
+  );
+});

--- a/tests/storyEngine.validateCurrentState.test.js
+++ b/tests/storyEngine.validateCurrentState.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// Minimal browser-like globals for modules that expect a DOM environment
+if (!globalThis.window) {
+  globalThis.window = {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => {}
+  };
+}
+
+if (!globalThis.localStorage) {
+  const storage = new Map();
+  globalThis.localStorage = {
+    getItem: (key) => storage.has(key) ? storage.get(key) : null,
+    setItem: (key, value) => storage.set(key, String(value)),
+    removeItem: (key) => storage.delete(key),
+    clear: () => storage.clear()
+  };
+}
+
+if (!globalThis.navigator) {
+  globalThis.navigator = { userAgent: 'node-test' };
+}
+
+if (!globalThis.location) {
+  globalThis.location = { href: 'http://localhost/test' };
+}
+
+const originalSetInterval = globalThis.setInterval;
+const originalClearInterval = globalThis.clearInterval;
+
+globalThis.setInterval = () => 0;
+globalThis.clearInterval = () => {};
+
+Object.assign(globalThis.window, {
+  location: globalThis.location,
+  localStorage: globalThis.localStorage,
+  navigator: globalThis.navigator
+});
+
+const { StoryEngine } = await import('../src/engine/StoryEngine.js');
+
+test('validateCurrentState provides combined stats and flags to validator', async (t) => {
+  t.after(() => {
+    globalThis.setInterval = originalSetInterval;
+    globalThis.clearInterval = originalClearInterval;
+  });
+
+  const engine = new StoryEngine();
+  engine.setValidationEnabled(true);
+
+  engine.adventure = {
+    id: 'adventure-test',
+    title: 'Adventure Test'
+  };
+
+  engine.currentScene = { id: 'start-scene' };
+
+  engine.statsManager.setStat('health', 42);
+  engine.statsManager.setFlag('questComplete', true);
+
+  const expectedResult = { errors: [], warnings: [], info: [] };
+  let receivedOptions;
+
+  engine.validationService = {
+    async validate(adventure, options) {
+      receivedOptions = options;
+      return expectedResult;
+    }
+  };
+
+  const result = await engine.validateCurrentState();
+
+  assert.strictEqual(result, expectedResult);
+  assert.ok(receivedOptions, 'validation should receive options');
+  assert.deepStrictEqual(receivedOptions.stats, {
+    stats: { health: 42 },
+    flags: { questComplete: true }
+  });
+  assert.strictEqual(receivedOptions.currentScene, 'start-scene');
+});

--- a/validation_test.js
+++ b/validation_test.js
@@ -1,6 +1,7 @@
 // Simple test to verify ValidationService functionality
 // This demonstrates all the key features implemented
 
+import './src/test/setupBrowserEnv.js';
 import { validationService } from './src/services/ValidationService.js';
 
 // Mock adventure with various validation scenarios


### PR DESCRIPTION
## Summary
- extend InventoryManager with a `setItemCount` helper that normalizes quantities, clamps to stack limits, removes empty entries, and reports outcomes while updating stats deltas
- route StoryEngine inventory actions through the helper results so success logs reuse the helper and failures raise clear warnings that cover `set_inventory`
- add bun-based coverage for `set_inventory`, share a browser-like test shim across suites, and hook the validation harness into the same setup to keep Node runs stable

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68cacd9fb5388327a7e0419ba1872a9d